### PR TITLE
Add Ability to Schedule a Revision

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "goldinteractive/craft3-publisher",
   "description": "",
-  "version": "2.1.0",
+  "version": "2.1.1-dev",
   "license": "MIT",
   "type": "craft-plugin",
   "require": {

--- a/src/controllers/EntriesController.php
+++ b/src/controllers/EntriesController.php
@@ -37,7 +37,18 @@ class EntriesController extends Controller
     {
         $this->requirePostRequest();
 
-        $draftId = Craft::$app->request->post('publisher_draftId');
+        $versionId = Craft::$app->request->post('publisher_versionId');
+
+        list($type, $tempId) = explode($versionId, '-');
+
+        if ( $type == 'draft' ) {
+            $draftId = $tempId;
+        } else {
+            $revisionId = $tempId;
+        }
+
+
+        // $draftId = Craft::$app->request->post('publisher_draftId');
         $publishAt = Craft::$app->request->post('publisher_publishAt');
         $siteId = Craft::$app->request->post('publisher_sourceSiteId');
 

--- a/src/controllers/EntriesController.php
+++ b/src/controllers/EntriesController.php
@@ -37,37 +37,55 @@ class EntriesController extends Controller
     {
         $this->requirePostRequest();
 
-        $versionId = Craft::$app->request->post('publisher_versionId');
-
-        list($type, $tempId) = explode($versionId, '-');
-
-        if ( $type == 'draft' ) {
-            $draftId = $tempId;
-        } else {
-            $revisionId = $tempId;
-        }
-
-
-        // $draftId = Craft::$app->request->post('publisher_draftId');
         $publishAt = Craft::$app->request->post('publisher_publishAt');
         $siteId = Craft::$app->request->post('publisher_sourceSiteId');
+        // $draftId = Craft::$app->request->post('publisher_draftId');
 
-        $draft = Entry::find()
-            ->draftId($draftId)
+        $versionId = Craft::$app->request->post('publisher_versionId');
+
+        list($type, $tempId) = explode('_', $versionId);
+
+        $draft = null;
+        $revision = null;
+        $entry = null;
+
+        if ( $type === 'draft' ) {
+            $draftId = $tempId;
+
+            $draft = Entry::find()
+                ->draftId($draftId)
+                ->siteId($siteId)
+                ->one();
+
+            if ($draft === null) {
+                throw new \Exception('Invalid entry draft ID: '.$draftId);
+            }
+
+            $entry = Craft::$app->entries->getEntryById($draft->getCanonicalId(), $siteId);
+        } else {
+            $revisionId = $tempId;
+
+            $revision = Entry::find()
+            ->revisionId($revisionId)
             ->siteId($siteId)
             ->one();
 
-        if ($draft === null) {
-            throw new \Exception('Invalid entry draft ID: '.$draftId);
-        }
+            if ($revision === null) {
+                throw new \Exception('Invalid entry draft ID: '.$revisionId);
+            }
 
-        $entry = Craft::$app->entries->getEntryById($draft->getCanonicalId(), $siteId);
+            $entry = Craft::$app->entries->getEntryById($revision->getCanonicalId(), $siteId);
+        }
 
         if ($entry === null) {
             throw new ElementNotFoundException("No element exists with the ID '{$draft->getCanonicalId()}'");
         }
 
-        if ($draft->enabled) {
+        if (isset($draft) and $draft->enabled) {
+            $this->requirePermission('publishEntries:'.$entry->section->uid);
+        }
+
+        if (isset($revision) and $revision->enabled) {
             $this->requirePermission('publishEntries:'.$entry->section->uid);
         }
 
@@ -77,7 +95,12 @@ class EntriesController extends Controller
 
         $model = new EntryPublish();
         $model->sourceId = $entry->id;
-        $model->publishDraftId = $draft->draftId;
+        if (isset($draft) and !empty($draft)) {
+            $model->publishDraftId = $draft->draftId;
+        }
+        if (isset($revision) and !empty($revision)) {
+            $model->publishRevisionId = $revision->revisionId;
+        }
         $model->publishAt = $publishAt;
         $model->sourceSiteId = $siteId;
 

--- a/src/elements/EntryPublish.php
+++ b/src/elements/EntryPublish.php
@@ -40,6 +40,11 @@ class EntryPublish extends Element
     public $publishDraftId;
 
     /**
+     * @var int
+     */
+    public $publishRevisionId;
+
+    /**
      * @var \DateTime
      */
     public $publishAt;
@@ -105,7 +110,7 @@ class EntryPublish extends Element
     public function rules(): array
     {
         $rules = parent::rules();
-        $rules[] = [['sourceId', 'sourceSiteId', 'publishDraftId'], 'number', 'integerOnly' => true];
+        $rules[] = [['sourceId', 'sourceSiteId', 'publishDraftId', 'publishRevisionId'], 'number', 'integerOnly' => true];
         $rules[] = [['publishAt'], DateTimeValidator::class];
         $rules[] = [['expire'], BooleanValidator::class];
 
@@ -145,6 +150,22 @@ class EntryPublish extends Element
         }
 
         return $draft;
+    }
+
+    /**
+     * Returns the entry revision.
+     *
+     * @return Entry|null
+     */
+    public function getRevision(): ?Entry
+    {
+
+        $revision = Entry::find()
+            ->revisionId($this->publishRevisionId)
+            ->siteId($this->sourceSiteId)
+            ->one();
+
+        return $revision;
     }
 
     /**

--- a/src/elements/db/EntryPublishQuery.php
+++ b/src/elements/db/EntryPublishQuery.php
@@ -29,6 +29,11 @@ class EntryPublishQuery extends ElementQuery
     public $publishDraftId;
 
     /**
+     * @var int|array|null The draft ID(s) to query for.
+     */
+    public $publishRevisionId;
+
+    /**
      * @var \DateTime|null The DateTime to query for.
      */
     public $publishAt;
@@ -113,6 +118,10 @@ class EntryPublishQuery extends ElementQuery
 
         if ($this->publishDraftId !== null) {
             $this->subQuery->andWhere(Db::parseParam('entrypublishes.publishDraftId', $this->publishDraftId));
+        }
+
+        if ($this->publishRevisionId !== null) {
+            $this->subQuery->andWhere(Db::parseParam('entrypublishes.publishRevisionId', $this->publishRevisionId));
         }
 
         if ($this->publishAt !== null) {

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -29,15 +29,16 @@ class Install extends Migration
             $this->createTable(
                 '{{%entrypublishes}}',
                 [
-                    'id'             => $this->integer()->notNull(),
-                    'sourceId'       => $this->integer()->notNull(),
-                    'sourceSiteId'   => $this->integer(),
-                    'publishDraftId' => $this->integer(),
-                    'publishAt'      => $this->dateTime()->notNull(),
-                    'expire'         => $this->boolean()->defaultValue(false),
-                    'dateCreated'    => $this->dateTime()->notNull(),
-                    'dateUpdated'    => $this->dateTime()->notNull(),
-                    'uid'            => $this->uid(),
+                    'id'                => $this->integer()->notNull(),
+                    'sourceId'          => $this->integer()->notNull(),
+                    'sourceSiteId'      => $this->integer(),
+                    'publishDraftId'    => $this->integer(),
+                    'publishRevisionId' => $this->integer(),
+                    'publishAt'         => $this->dateTime()->notNull(),
+                    'expire'            => $this->boolean()->defaultValue(false),
+                    'dateCreated'       => $this->dateTime()->notNull(),
+                    'dateUpdated'       => $this->dateTime()->notNull(),
+                    'uid'               => $this->uid(),
                     'PRIMARY KEY([[id]])',
                 ]
             );
@@ -51,6 +52,15 @@ class Install extends Migration
                 '{{%entrypublishes}}',
                 ['publishDraftId'],
                 '{{%drafts}}',
+                ['id'],
+                'CASCADE',
+                'CASCADE'
+            );
+            $this->addForeignKey(
+                null,
+                '{{%entrypublishes}}',
+                ['publishRevisionId'],
+                '{{%revisions}}',
                 ['id'],
                 'CASCADE',
                 'CASCADE'

--- a/src/records/EntryPublish.php
+++ b/src/records/EntryPublish.php
@@ -21,6 +21,7 @@ use yii\db\ActiveQueryInterface;
  * @property int       $sourceId
  * @property int       $sourceSiteId
  * @property int       $publishDraftId
+ * @property int       $publishRevisionId
  * @property bool      $expire
  * @property \DateTime $publishAt
  */
@@ -62,5 +63,15 @@ class EntryPublish extends ActiveRecord
     public function getDraft(): ActiveQueryInterface
     {
         return $this->hasOne(Element::class, ['id' => 'publishDraftId']);
+    }
+
+    /**
+     * Returns the entry revision.
+     *
+     * @return ActiveQueryInterface
+     */
+    public function getRevision(): ActiveQueryInterface
+    {
+        return $this->hasOne(Element::class, ['id' => 'publishRevisionId']);
     }
 }

--- a/src/services/Entries.php
+++ b/src/services/Entries.php
@@ -56,11 +56,14 @@ class Entries extends Component
         foreach ($publishEntries as $entryPublish) {
             $entry = $entryPublish->getEntry();
             $draft = $entryPublish->getDraft();
+            $revision = $entryPublish->getRevision();
 
             Craft::$app->elements->deleteElement($entryPublish, true);
 
             if ($draft !== null) {
                 Craft::$app->getDrafts()->applyDraft($draft);
+            } elseif ($revision !== null) {
+                Craft::$app->getRevisions()->revertToRevision($revision, $revision->authorId);
             } elseif ($entry !== null) {
                 try {
                     Craft::$app->elements->saveElement($entry);
@@ -125,6 +128,7 @@ class Entries extends Component
         $record->sourceId = $model->sourceId;
         $record->sourceSiteId = $model->sourceSiteId;
         $record->publishDraftId = $model->publishDraftId;
+        $record->publishRevisionId = $model->publishRevisionId;
         $record->publishAt = $model->publishAt;
         $record->expire = $model->expire;
 

--- a/src/templates/_cp/entriesEditRightPane.twig
+++ b/src/templates/_cp/entriesEditRightPane.twig
@@ -17,7 +17,7 @@
             </div>
 
             {% for pendingEntry in pendingEntries %}
-                {% set title = pendingEntry.draft ? pendingEntry.draft.draftName : pendingEntry.entry.title %}
+                {% set title = pendingEntry.draft ? pendingEntry.draft.draftName : (pendingEntry.revision ? pendingEntry.revision.getRevisionLabel() : pendingEntry.entry.title) %}
                 <div class="data">
                     <h5>{{ title }}{{ pendingEntry.expire ? ' ('~'Expires'|t('publisher')~')' }}</h5>
                     <div class="value">
@@ -31,7 +31,7 @@
     </div>
 </div>
 
-{% if drafts|length > 0 and canPublishDraft %}
+{% if (drafts|length > 0 or revisions|length > 1) and canPublishDraft %}
     <div class="meta" style="padding-top: 14px; padding-bottom: 14px;">
         <div class="data">
             <h4>{{ 'Schedule a publish date'|t('publisher') }}</h4>
@@ -42,10 +42,10 @@
                 <div class="select">
                     <select name="publisher_versionId">
                         {% for draft in drafts %}
-                            <option value="draft-{{ draft.draftId }}">{{ draft.draftName }}</option>
+                            <option value="draft_{{ draft.draftId }}">{{ draft.draftName }}</option>
                         {% endfor %}
                         {% for revision in revisions %}
-                            <option value="revision-{{ revision.revisionId }}">
+                            <option value="revision_{{ revision.revisionId }}">
                                 {% if entry.currentRevision().revisionId == revision.revisionId %}
                                     {{ 'Current Revision' }}
                                 {% else %}

--- a/src/templates/_cp/entriesEditRightPane.twig
+++ b/src/templates/_cp/entriesEditRightPane.twig
@@ -1,6 +1,7 @@
 {% import "_includes/forms" as forms %}
 {% set pendingEntries = craft.publisherEntries.getPendingEntries(entry.id) %}
 {% set drafts = craft.entries.draftOf(entry.id).siteId(entry.site.id).all %}
+{% set revisions = craft.entries.revisionOf(entry.id).siteId(entry.site.id).all %}
 {% set canPublishDraft = currentUser.can('publishEntries'~permissionSuffix) %}
 {% set isVersion = className(entry) == 'craft\\models\\EntryVersion' %}
 
@@ -36,12 +37,27 @@
             <h4>{{ 'Schedule a publish date'|t('publisher') }}</h4>
         </div>
         <div class="field">
-            <div class="heading"><label>{{ 'Draft'|t('publisher') }}</label></div>
+            <div class="heading"><label>{{ 'Draft or Revision'|t('publisher') }}</label></div>
             <div class="input">
                 <div class="select">
-                    <select name="publisher_draftId">
+                    <select name="publisher_versionId">
                         {% for draft in drafts %}
-                            <option value="{{ draft.draftId }}">{{ draft.draftName }}</option>
+                            <option value="draft-{{ draft.draftId }}">{{ draft.draftName }}</option>
+                        {% endfor %}
+                        {% for revision in revisions %}
+                            <option value="revision-{{ revision.revisionId }}">
+                                {% if entry.currentRevision().revisionId == revision.revisionId %}
+                                    {{ 'Current Revision' }}
+                                {% else %}
+                                    {{ revision.getRevisionLabel() }}
+                                {% endif %}
+                                    {{ creator ? 'Saved {timestamp} by {creator}'|t('app', {
+                                        timestamp: revision.dateCreated|timestamp('short', withPreposition=true),
+                                        creator: creator.name,
+                                    }) : 'Saved {timestamp}'|t('app', {
+                                        timestamp: revision.dateCreated|timestamp('short', withPreposition=true),
+                                    }) }}
+                            </option>
                         {% endfor %}
                     </select>
                 </div>


### PR DESCRIPTION
We had a need to schedule a draft, but then also schedule returning to the initial state. Unfortunately, something to do with the way Neo blocks function, we weren't able to create two drafts from the same point and schedule both (Draft 1 would write, and then the Draft 2 diffs would see the committed Draft 1 diffs as more up to date and would not implement Draft 2 changes)

We updated the publisher package to allow for scheduling a revision (including the current revision). Revisions are seen as an absolute truth and don't use a diff function to apply changes (like the issues we saw with scheduling drafts)
